### PR TITLE
Allow 20 open dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 20
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
since there always are a number of dependencies held back by tensorflow