### PR TITLE
Improve typechecking of channel update function.

### DIFF
--- a/nanotune/device/device.py
+++ b/nanotune/device/device.py
@@ -3,7 +3,7 @@ import copy
 import logging
 from enum import Enum
 from typing import (
-    Any, Dict, Optional, Sequence, Tuple, Union, Mapping, Sequence, List
+    Any, Dict, Optional, Sequence, Tuple, Union, Mapping, Sequence, List, MutableMapping
 )
 
 import numpy as np
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 nrm_cnst_tp = Mapping[str, Tuple[float, float]]
 voltage_range_type = Dict[int, Sequence[float]]
 
+
+ChannelsType = Optional[
+            Union[MutableMapping[str, MutableMapping[str, Any]], MutableMapping[str, str]]]
 
 @dataclass
 class NormalizationConstants:
@@ -188,7 +191,7 @@ class Device(DelegateInstrument):
         parameters: Optional[
             Union[Mapping[str, Sequence[str]], Mapping[str, str]]] = None,
         channels: Optional[
-            Union[Mapping[str, Mapping[str, Any]], Mapping[str, str]]] = None,
+            Union[MutableMapping[str, MutableMapping[str, Any]], MutableMapping[str, str]]] = None,
         readout: Optional[Mapping[str, str]] = None,
         main_readout_method: Union[ReadoutMethods, str] = ReadoutMethods.transport,
         initial_values: Optional[Mapping[str, Any]] = None,
@@ -609,15 +612,15 @@ class Device(DelegateInstrument):
 
 def _add_station_and_label_to_channel_init(
     station: qc.Station,
-    channels: Optional[Mapping[str, Union[str, Mapping[str, Any]]]] = None,
-) -> Optional[Mapping[str, Union[str, Any]]]:
+    channels: ChannelsType = None,
+) -> ChannelsType:
     if channels is None:
         return None
     for name, channel_value in channels.items():
-        if isinstance(channel_value, Mapping):
+        if isinstance(channel_value, MutableMapping):
             if 'station' not in channel_value.keys():
-                channel_value['station'] = station  # type: ignore
+                channel_value['station'] = station
             if 'label' not in channel_value.keys():
-                channel_value['label'] = name  # type: ignore
+                channel_value['label'] = name
 
     return channels


### PR DESCRIPTION
This functions modifies the input mapping. So it should be annotated as a mutable mapping. To make things simpler I have defined a typealias that is used everywhere this is used. That changes the type of the private function to the type of the input variable but these should be the same since this is only used once 